### PR TITLE
Fix unit tests assertion

### DIFF
--- a/src/main/resources/archetype-resources/glassfish/src/test/java/jakarta/cafe/rest/CafeResourceTest.java
+++ b/src/main/resources/archetype-resources/glassfish/src/test/java/jakarta/cafe/rest/CafeResourceTest.java
@@ -76,8 +76,8 @@ public class CafeResourceTest {
 		coffee = query.getSingleResult();
 
 		assertNotNull(coffee);
-		assertEquals(coffee.getName(), "Test-A");
-		assertEquals(coffee.getPrice().doubleValue(), 7.25, 0);
+		assertEquals("Test-A", coffee.getName());
+		assertEquals(7.25, coffee.getPrice(), 0);
 	}
 
 	@Test
@@ -92,8 +92,8 @@ public class CafeResourceTest {
 				.request(MediaType.APPLICATION_JSON).get(Coffee.class);
 
 		assertNotNull(coffee);
-		assertEquals(coffee.getName(), "Test-B");
-		assertEquals(coffee.getPrice().doubleValue(), 5.99, 0);
+		assertEquals("Test-B", coffee.getName());
+		assertEquals(5.99, coffee.getPrice(), 0);
 	}
 
 	@Test
@@ -112,13 +112,13 @@ public class CafeResourceTest {
 				.get(new GenericType<List<Coffee>>() {
 				});
 
-		assertEquals(coffees.size(), 3);
-		assertEquals(coffees.get(0).getName(), "Test-C");
-		assertEquals(coffees.get(0).getPrice().doubleValue(), 4.75, 0);
-		assertEquals(coffees.get(1).getName(), "Test-D");
-		assertEquals(coffees.get(1).getPrice().doubleValue(), 1.99, 0);
-		assertEquals(coffees.get(2).getName(), "Test-E");
-		assertEquals(coffees.get(2).getPrice().doubleValue(), 2.95, 0);
+		assertEquals(3, coffees.size());
+		assertEquals("Test-C", coffees.get(0).getName());
+		assertEquals(4.75, coffees.get(0).getPrice(), 0);
+		assertEquals("Test-D", coffees.get(1).getName());
+		assertEquals(1.99, coffees.get(1).getPrice(), 0);
+		assertEquals("Test-E", coffees.get(2).getName());
+		assertEquals(2.95, coffees.get(2).getPrice(), 0);
 	}
 
 	@Test

--- a/src/main/resources/archetype-resources/src/test/java/jakarta/cafe/rest/CafeResourceTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/jakarta/cafe/rest/CafeResourceTest.java
@@ -75,8 +75,8 @@ public class CafeResourceTest {
 		coffee = query.getSingleResult();
 
 		assertNotNull(coffee);
-		assertEquals(coffee.getName(), "Test-A");
-		assertEquals(coffee.getPrice().doubleValue(), 7.25, 0);
+		assertEquals("Test-A", coffee.getName());
+		assertEquals(7.25, coffee.getPrice(), 0);
 	}
 
 	@Test
@@ -91,8 +91,8 @@ public class CafeResourceTest {
 				.request(MediaType.APPLICATION_JSON).get(Coffee.class);
 
 		assertNotNull(coffee);
-		assertEquals(coffee.getName(), "Test-B");
-		assertEquals(coffee.getPrice().doubleValue(), 5.99, 0);
+		assertEquals("Test-B", coffee.getName());
+		assertEquals(5.99, coffee.getPrice(), 0);
 	}
 
 	@Test
@@ -111,13 +111,13 @@ public class CafeResourceTest {
 				.get(new GenericType<List<Coffee>>() {
 				});
 
-		assertEquals(coffees.size(), 3);
-		assertEquals(coffees.get(0).getName(), "Test-C");
-		assertEquals(coffees.get(0).getPrice().doubleValue(), 4.75, 0);
-		assertEquals(coffees.get(1).getName(), "Test-D");
-		assertEquals(coffees.get(1).getPrice().doubleValue(), 1.99, 0);
-		assertEquals(coffees.get(2).getName(), "Test-E");
-		assertEquals(coffees.get(2).getPrice().doubleValue(), 2.95, 0);
+		assertEquals(3, coffees.size());
+		assertEquals("Test-C", coffees.get(0).getName());
+		assertEquals(4.75, coffees.get(0).getPrice(), 0);
+		assertEquals("Test-D", coffees.get(1).getName());
+		assertEquals(1.99, coffees.get(1).getPrice(), 0);
+		assertEquals("Test-E", coffees.get(2).getName());
+		assertEquals(2.95, coffees.get(2).getPrice(), 0);
 	}
 
 	@Test

--- a/src/main/resources/archetype-resources/tomee/src/test/java/jakarta/cafe/rest/CafeResourceTest.java
+++ b/src/main/resources/archetype-resources/tomee/src/test/java/jakarta/cafe/rest/CafeResourceTest.java
@@ -76,8 +76,8 @@ public class CafeResourceTest {
 		coffee = query.getSingleResult();
 
 		assertNotNull(coffee);
-		assertEquals(coffee.getName(), "Test-A");
-		assertEquals(coffee.getPrice().doubleValue(), 7.25, 0);
+		assertEquals("Test-A", coffee.getName());
+		assertEquals(7.25, coffee.getPrice(), 0);
 	}
 
 	@Test
@@ -92,8 +92,8 @@ public class CafeResourceTest {
 				.request(MediaType.APPLICATION_JSON).get(Coffee.class);
 
 		assertNotNull(coffee);
-		assertEquals(coffee.getName(), "Test-B");
-		assertEquals(coffee.getPrice().doubleValue(), 5.99, 0);
+		assertEquals("Test-B", coffee.getName());
+		assertEquals(5.99, coffee.getPrice(), 0);
 	}
 
 	@Test
@@ -112,13 +112,13 @@ public class CafeResourceTest {
 				.get(new GenericType<List<Coffee>>() {
 				});
 
-		assertEquals(coffees.size(), 3);
-		assertEquals(coffees.get(0).getName(), "Test-C");
-		assertEquals(coffees.get(0).getPrice().doubleValue(), 4.75, 0);
-		assertEquals(coffees.get(1).getName(), "Test-D");
-		assertEquals(coffees.get(1).getPrice().doubleValue(), 1.99, 0);
-		assertEquals(coffees.get(2).getName(), "Test-E");
-		assertEquals(coffees.get(2).getPrice().doubleValue(), 2.95, 0);
+		assertEquals(3, coffees.size());
+		assertEquals("Test-C", coffees.get(0).getName());
+		assertEquals(4.75, coffees.get(0).getPrice(), 0);
+		assertEquals("Test-D", coffees.get(1).getName());
+		assertEquals(1.99, coffees.get(1).getPrice(), 0);
+		assertEquals("Test-E", coffees.get(2).getName());
+		assertEquals(2.95, coffees.get(2).getPrice(), 0);
 	}
 
 	@Test


### PR DESCRIPTION
It looks like the assertEquals have the expected, actual reversed.
(see https://junit.org/junit4/javadoc/latest/org/junit/Assert.html)

Although it still validates correctly, we may get a more confusing error message.

E.g. should be:

```assertEquals(3, coffees.size());```

instead of:

`assertEquals(coffees.size(), 3);`

I think this is a change worth making.