### PR TITLE
Fix thread number computation in Maven Project Generator #153

### DIFF
--- a/maven-project-generator/src/main/java/org/eclipse/starter/mavengenerator/MavenParameters.java
+++ b/maven-project-generator/src/main/java/org/eclipse/starter/mavengenerator/MavenParameters.java
@@ -13,6 +13,7 @@ public class MavenParameters {
     protected Optional<Boolean> interactiveMode = Optional.empty();
     protected Optional<Integer> numberOfThreads = Optional.empty();
     protected List<String> goals = new ArrayList<>();
+    protected boolean guessNumberOfThreads = false;
 
     public MavenParameters interactiveMode(final Boolean value) {
         this.interactiveMode = Optional.ofNullable(value);
@@ -21,6 +22,11 @@ public class MavenParameters {
 
     public MavenParameters numberOfThreads(final Integer i) {
         this.numberOfThreads = Optional.ofNullable(i);
+        return this;
+    }
+    
+    public MavenParameters guessNumberOfThreads() {
+        this.guessNumberOfThreads = true;
         return this;
     }
 
@@ -43,11 +49,17 @@ public class MavenParameters {
 
     protected List<String> getOptions() {
         List<String> options = new ArrayList<>();
-        Integer finalNumberOfThreads = numberOfThreads
-                .orElseGet(() -> {
-                    return Runtime.getRuntime().availableProcessors() / 2;
+        Optional<Integer> finalNumberOfThreads = numberOfThreads
+                .or(() -> {
+                    if (guessNumberOfThreads) {
+                        return Optional.of(Runtime.getRuntime().availableProcessors() / 2 + 1);
+                    } else {
+                        return Optional.empty();
+                    }
                 });
-        options.add("-T" + finalNumberOfThreads);
+        finalNumberOfThreads.ifPresent( numberOfThreads -> {
+            options.add("-T" + numberOfThreads);
+        });
         return options;
     }
 


### PR DESCRIPTION
There was a flaw in guessing the number of threads for Maven on a single core processor. That resulted in running Maven with -T 0, leading to `IllegalArgumentException` in `ThreadPoolExecutor`: https://gist.github.com/rokon12/fbdadd05ad21e12e6bd166b2156420fa

I fixed this and also disabled automatic computation of the number of threads by default. So the ZIP generation always uses 1 thread.