### PR TITLE
Add jsf on starter-ui project

### DIFF
--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -50,6 +50,26 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.0.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.primefaces</groupId>
+            <artifactId>primefaces</artifactId>
+            <version>12.0.0</version>
+            <classifier>jakarta</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>10.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>4.9.0</version>

--- a/starter-ui/src/main/java/org/eclipse/starter/ui/JakartaEEVersion.java
+++ b/starter-ui/src/main/java/org/eclipse/starter/ui/JakartaEEVersion.java
@@ -1,0 +1,23 @@
+package org.eclipse.starter.ui;
+
+public enum JakartaEEVersion {
+  JAKARTA_EE_10("Jakarta EE 10", "jakartaee10-minimal"),
+  JAKARTA_EE_9_1("Jakarta EE 9.1", "jakartaee9.1-minimal"),
+  JAKARTA_EE_8("Jakarta EE 8", "jakartaee8-minimal"),
+  ;
+  private final String displayName;
+  private final String archeTypeArtifactId;
+
+  JakartaEEVersion(final String displayName, final String archeTypeArtifactId) {
+    this.displayName = displayName;
+    this.archeTypeArtifactId = archeTypeArtifactId;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public String getArcheTypeArtifactId() {
+    return archeTypeArtifactId;
+  }
+}

--- a/starter-ui/src/main/java/org/eclipse/starter/ui/Profile.java
+++ b/starter-ui/src/main/java/org/eclipse/starter/ui/Profile.java
@@ -1,0 +1,23 @@
+package org.eclipse.starter.ui;
+
+public enum Profile {
+  PLATFORM("Platform","api"),
+  WEB_PROFILE("Web Profile","web-api"),
+  CORE_PROFILE("Core Profile","core-api");
+
+  private final String displayName;
+  private  final String profile;
+
+  Profile(final String displayName, final String profile) {
+    this.displayName = displayName;
+    this.profile = profile;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public String getProfile() {
+    return profile;
+  }
+}

--- a/starter-ui/src/main/java/org/eclipse/starter/ui/Project.java
+++ b/starter-ui/src/main/java/org/eclipse/starter/ui/Project.java
@@ -1,0 +1,104 @@
+package org.eclipse.starter.ui;
+
+
+import static java.util.logging.Level.SEVERE;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+@Named
+@RequestScoped
+public class Project {
+
+  private static final Logger logger = Logger.getLogger(
+      MethodHandles.lookup().lookupClass().getName());
+  private static final String ARCHETYPE_GROUP_ID = "org.eclipse.starter";
+  private static final String ARCHETYPE_VERSION = "1.1.0";
+
+  private JakartaEEVersion jakartaEEVersion;
+  private Profile profile;
+  private String groupId = "com.example";
+  private String artifactId = "demo";
+  private String version = "1.0.0-SNAPSHOT"; //default value
+
+  public JakartaEEVersion getJakartaEEVersion() {
+    return jakartaEEVersion;
+  }
+
+  public void setJakartaEEVersion(final JakartaEEVersion jakartaEEVersion) {
+    this.jakartaEEVersion = jakartaEEVersion;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(final String groupId) {
+    this.groupId = groupId;
+  }
+
+  public String getArtifactId() {
+    return artifactId;
+  }
+
+  public void setArtifactId(final String artifactId) {
+    this.artifactId = artifactId;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
+  }
+
+  public Profile getProfile() {
+    return profile;
+  }
+
+  public void setProfile(final Profile profile) {
+    this.profile = profile;
+  }
+
+  public void generate() {
+    final var downloadUrl = String.format(
+        "/download.zip?archetypeGroupId=%s&archetypeArtifactId=%s&archetypeVersion=%s&groupId=%s&artifactId=%s&profile=%s&version=%s",
+        ARCHETYPE_GROUP_ID, jakartaEEVersion.getArcheTypeArtifactId(), ARCHETYPE_VERSION, groupId,
+        artifactId, profile.getProfile(), version);
+
+    var context = FacesContext.getCurrentInstance();
+    var response = (HttpServletResponse) context.getExternalContext().getResponse();
+    context.responseComplete();
+    try {
+      final var redirectUrl = getApplicationUri()
+          .map(root -> root + downloadUrl)
+          .orElse(downloadUrl);
+      response.sendRedirect(redirectUrl + "?faces-redirect=true");
+    } catch (IOException e) {
+      logger.log(SEVERE, "Was not able to generate file", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Optional<String> getApplicationUri() {
+    try {
+      var ext = FacesContext.getCurrentInstance().getExternalContext();
+      var uri = new URI(ext.getRequestScheme(),
+          null, ext.getRequestServerName(), ext.getRequestServerPort(),
+          ext.getRequestContextPath(), null, null);
+      return Optional.of(uri.toASCIIString());
+    } catch (URISyntaxException e) {
+      logger.log(SEVERE, "Was not able to get context path", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/starter-ui/src/main/java/org/eclipse/starter/ui/StarterServlet.java
+++ b/starter-ui/src/main/java/org/eclipse/starter/ui/StarterServlet.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 import java.util.stream.Stream;
 import java.util.zip.ZipOutputStream;
 
-@WebServlet(urlPatterns = {"/download.zip"}, name = "StarterServlet")
+@WebServlet(urlPatterns = {"/download.zip"}, name = "StarterServlet", loadOnStartup = 1)
 public class StarterServlet extends HttpServlet {
 
     private static final Logger logger = Logger.getLogger(

--- a/starter-ui/src/main/webapp/WEB-INF/faces-config.xml
+++ b/starter-ui/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config
+  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+  version="4.0"
+>
+  <!-- Put any faces config here. -->
+</faces-config>

--- a/starter-ui/src/main/webapp/WEB-INF/web.xml
+++ b/starter-ui/src/main/webapp/WEB-INF/web.xml
@@ -3,7 +3,29 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
   version="5.0">
+  <servlet>
+    <servlet-name>facesServlet</servlet-name>
+    <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>facesServlet</servlet-name>
+    <url-pattern>*.xhtml</url-pattern>
+  </servlet-mapping>
+
+  <context-param>
+    <param-name>
+      jakarta.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL
+    </param-name>
+    <param-value>true</param-value>
+  </context-param>
+  <context-param>
+    <param-name>primefaces.THEME</param-name>
+    <param-value>saga</param-value>
+  </context-param>
+
   <welcome-file-list>
-    <welcome-file>/html/index.html</welcome-file>
+    <welcome-file>index.xhtml</welcome-file>
   </welcome-file-list>
+
 </web-app>

--- a/starter-ui/src/main/webapp/index.xhtml
+++ b/starter-ui/src/main/webapp/index.xhtml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html
+  xmlns:f="jakarta.faces.core"
+  xmlns:h="jakarta.faces.html"
+  xmlns:p="http://primefaces.org/ui">
+<p:importEnum type="org.eclipse.starter.ui.JakartaEEVersion"/>
+<p:importEnum type="org.eclipse.starter.ui.Profile"/>
+<style>
+  .text-align-left {
+    text-align: left;
+  }
+</style>
+
+<h:head>
+
+</h:head>
+<h:body>
+  <p>Welcome to the official Eclipse Foundation starter for Jakarta EE. The starter is a Maven
+    Archetype that generates sample code to get you going quickly with simple Jakarta EE
+    microservices
+    projects. The starter will include a web UI in a subsequent release.
+  </p>
+  <h1>Generate Jakarta EE Project
+  </h1>
+  <p>
+    In order to run the Maven Archetype and generate a sample Jakarta EE project, please execute the
+    following. Please ensure you have installed a Java <a
+    href="https://adoptium.net/?variant=openjdk8">SE 8+ implementation</a> and <a
+    href="https://maven.apache.org/download.cgi">Maven 3+</a> (we have tested with Java SE 8, Java
+    SE 11 and Java SE 17).
+  </p>
+
+
+  <p:panel header="Generate a Jakarta EE Project">
+    <div class="card">
+      <h:form>
+        <p:panelGrid columns="4" layout="grid" styleClass="text-align-left">
+          <p:outputLabel for="@next"
+                         value="Jakarta EE Version"/>
+          <p:selectOneMenu value="#{project.jakartaEEVersion}" required="true">
+            <f:selectItems value="#{JakartaEEVersion.ALL_VALUES}"
+                           itemLabel="#{element.displayName}" itemValue="#{element}" var="element"/>
+          </p:selectOneMenu>
+          <p:message for="@previous"/>
+          <h:outputText/>
+
+          <p:outputLabel for="@next" value="Profile"/>
+          <p:selectOneMenu value="#{project.profile}" required="true">
+            <f:selectItems value="#{Profile.ALL_VALUES}"
+                           itemLabel="#{element.displayName}" itemValue="#{element}" var="element"/>
+
+          </p:selectOneMenu>
+          <p:message for="@previous"/>
+          <h:outputText/>
+
+          <p:outputLabel for="@next" value="groupId"/>
+          <p:inputText value="#{project.groupId}" required="true"
+                       requiredMessage="groupId is required.">
+          </p:inputText>
+          <p:message for="@previous"/>
+          <h:outputText/>
+
+          <p:outputLabel for="@next" value="artifactId"/>
+          <p:inputText value="#{project.artifactId}"
+                       required="true"
+                       requiredMessage="artifactId is required.">
+          </p:inputText>
+          <p:message for="@previous"/>
+          <h:outputText/>
+
+          <p:outputLabel for="@next" value="version"/>
+          <p:inputText value="#{project.version}" required="true"
+                       requiredMessage="version is required.">
+          </p:inputText>
+          <p:message for="@previous"/>
+          <h:outputText/>
+        </p:panelGrid>
+
+        <p:commandButton value="GENERATE" ajax="false"
+                         icon="pi pi-arrow-down" styleClass="mr-2"
+                         action="#{project.generate}">
+        </p:commandButton>
+      </h:form>
+    </div>
+  </p:panel>
+
+</h:body>
+</html>


### PR DESCRIPTION
This is the first step toward moving the starter ui to JSF. When you run this on WeldFly, the first page will be a simple form where you can specify your requirements and download a sample project.

The UI indeed require facelifting though. 
![image](https://user-images.githubusercontent.com/429073/204706471-9a2842b6-82b6-4c3b-a705-3abbe033bf66.png)
