### PR TITLE
Adjust Open Liberty - specific config/doc

### DIFF
--- a/archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/archetype/src/main/resources/archetype-resources/Dockerfile
@@ -73,13 +73,13 @@
 #end
 #if (${runtime} == 'open-liberty')
     #if (${javaVersion} == '17')
-        #set ($baseImage = "openliberty/open-liberty:22.0.0.9-full-java17-openj9-ubi")
+        #set ($baseImage = "icr.io/appcafe/open-liberty:full-java17-openj9-ubi")
     #elseif (${javaVersion} == '11')
-        #set ($baseImage = "openliberty/open-liberty:22.0.0.9-full-java11-openj9-ubi")
+        #set ($baseImage = "icr.io/appcafe/open-liberty:full-java11-openj9-ubi")
     #else
-        #set ($baseImage = "openliberty/open-liberty:22.0.0.9-full-java8-openj9-ubi")
+        #set ($baseImage = "icr.io/appcafe/open-liberty:full-java8-openj9-ubi")
     #end
-    #set ($deployDirectory = "/config/dropins/")    
+    #set ($deployDirectory = "/config/apps/")    
 #end
 FROM $baseImage
 #if (${runtime} == 'open-liberty')

--- a/archetype/src/main/resources/archetype-resources/README.md
+++ b/archetype/src/main/resources/archetype-resources/README.md
@@ -15,14 +15,14 @@ You can run the application by executing the following command from the director
 #elseif (${runtime} == 'wildfly')
 ./mvnw clean package wildfly:run
 #elseif (${runtime} == 'open-liberty')
-./mvnw clean package liberty:run
+./mvnw clean package liberty:dev
 #end
 ```
 
 #if ((${runtime} == 'payara') && (${profile} != 'full'))
 Once the runtime starts, you can access the project at http://localhost:8080.
 #elseif (${runtime} == 'open-liberty')
-Once the runtime starts, you can access the project at http://localhost:9080/jakartaee-hello-world.
+Once the runtime starts, you can access the project at http://localhost:9080.
 #else
 Once the runtime starts, you can access the project at http://localhost:8080/jakartaee-hello-world.
 #end
@@ -48,7 +48,7 @@ docker run -it --rm -p 9080:9080 jakartaee-hello-world:v1
 #if (${runtime} != 'open-liberty')
 Once the runtime starts, you can access the project at http://localhost:8080/jakartaee-hello-world.
 #else
-Once the runtime starts, you can access the project at http://localhost:9080/jakartaee-hello-world.
+Once the runtime starts, you can access the project at http://localhost:9080/.
 #end
 #end
 #else

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -214,20 +214,9 @@
 				<groupId>io.openliberty.tools</groupId>
 				<artifactId>liberty-maven-plugin</artifactId>
 				<version>${liberty-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>package-server</id>
-						<phase>package</phase>
-						<goals>
-							<goal>create</goal>
-							<goal>install-feature</goal>
-							<goal>deploy</goal>
-						</goals>
-						<configuration>
-							<libertyRuntimeVersion>${open-liberty.version}</libertyRuntimeVersion>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<libertyRuntimeVersion>${open-liberty.version}</libertyRuntimeVersion>
+				</configuration>
 			</plugin>			
 			#end			
 		</plugins>

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -77,7 +77,7 @@
 		<wildfly.version>${wildflyVersion}</wildfly.version>
         #end
 		#if (${runtime} == 'open-liberty')
-		<open-liberty.version>22.0.0.13</open-liberty.version>
+		<open-liberty.version>RELEASE</open-liberty.version>
         #end
 		<compiler-plugin.version>3.10.1</compiler-plugin.version>
 		<war-plugin.version>3.2.2</war-plugin.version>

--- a/archetype/src/main/resources/archetype-resources/src/main/liberty/config/server.xml
+++ b/archetype/src/main/resources/archetype-resources/src/main/liberty/config/server.xml
@@ -22,4 +22,6 @@
     <keyStore id="defaultKeyStore" password="password" />
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" httpsPort="9443" /> 
+
+    <webApplication location="jakartaee-hello-world.war" contextRoot="/"/>
 </server>


### PR DESCRIPTION
A few changes:
1. Deploy to 'apps' rather than dropins and configure with location in server.xml,
2. Switch to '/' context root
3. Remove the "package-server" execution from the lifecycle (from 'package' phase).  
4. switch from 'liberty:run' to 'liberty:dev' as getting started command in README:
(to mvnw clean package liberty:dev  - arguably unneeded to clean after generating a new project but other runtimes do this so this is small improvement without revisiting the pattern.    
5. Switch to Runtime version 'latest'.  Right now it's hard-coded to 220013 in Maven and 22009 in Docker.   I think let's just move to "latest".... and worry about adding a runtime version parameter perhaps later
6. Switch registry from DockerHub to IBM Container Registry (no rate limits, no auth needed)