### PR TITLE
Simplify Liberty instruction in generated README.md

### DIFF
--- a/archetype/src/main/resources/archetype-resources/README.md
+++ b/archetype/src/main/resources/archetype-resources/README.md
@@ -15,7 +15,7 @@ You can run the application by executing the following command from the director
 #elseif (${runtime} == 'wildfly')
 ./mvnw clean package wildfly:run
 #elseif (${runtime} == 'open-liberty')
-./mvnw clean package liberty:dev
+./mvnw liberty:dev
 #end
 ```
 

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -208,7 +208,7 @@
 				</configuration>
 			</plugin>
 #elseif (${runtime} == 'open-liberty')
-			<!-- Execute 'mvn clean package liberty:dev' to run the application. -->
+			<!-- Execute 'mvn liberty:dev' to run the application, 'mvn package' to prepare for the Docker build.  -->
 			<plugin>
 				<groupId>io.openliberty.tools</groupId>
 				<artifactId>liberty-maven-plugin</artifactId>


### PR DESCRIPTION
Typically there won't be any value in running the `clean package` phases first.  

It might look a bit asymmetric in the source here, but once the project is generated you're only going to see the runtime-specific instruction so I'm going to go for it.