### PR TITLE
Remove hard-coded (out-of-date) references to archetype version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mvn clean install
 In order to run the Maven Archetype and generate a sample Jakarta EE project, please execute the following. Please ensure you have installed a [Java SE 8+ implementation](https://adoptium.net/?variant=openjdk8) and [Maven 3+](https://maven.apache.org/download.cgi) (we have tested with Java SE 8, Java SE 11 and Java SE 17).
 
 ```
-mvn archetype:generate -DarchetypeGroupId="org.eclipse.starter" -DarchetypeArtifactId="jakarta-starter" -DarchetypeVersion="2.0-SNAPSHOT"
+mvn archetype:generate -DarchetypeGroupId="org.eclipse.starter" -DarchetypeArtifactId="jakarta-starter"
 ```
 
 If you use the defaults, this will generate the Jakarta EE project under a directory named `jakartaee-hello-world`. The README.md file 
@@ -30,7 +30,7 @@ under that directory will contain instructions on how to run the sample.
 If desired, you can easily use the Maven Archetype from a Maven capable IDE such as [Eclipse](https://www.eclipse.org/ide). The generated starter code is simply Maven projects. You can easily load, explore and run the code in a Maven capable IDE such as [Eclipse](https://www.eclipse.org/ide).
 
 ##  Running the UI
-In order to run the UI, please execute the following from this directory. You can also simply build the war from Maven and deploy the war to either WildFly 26 or JBoss EAP 7.4. You can do this in an IDE if desired. Note that you can override the underlying archetype version used by setting the `ARCHETYPE_VERSION` environment variable (the default version assumed is 2.0.0).
+In order to run the UI, please execute the following from this directory. You can also simply build the war from Maven and deploy the war to either WildFly 26 or JBoss EAP 7.4. You can do this in an IDE if desired. Note that you can override the underlying archetype version used by setting the `ARCHETYPE_VERSION` environment variable (the default version will be the most recent, see [here](https://github.com/eclipse-ee4j/starter/#readme) for the latest value).
 
 ```
 mvn clean package wildfly:run --file ui/pom.xml

--- a/archetype/README.md
+++ b/archetype/README.md
@@ -15,7 +15,7 @@ mvn clean install
 In order to run the Maven Archetype and generate a sample Jakarta EE project, please execute the following. Please ensure you have installed a [Java SE 8+ implementation](https://adoptium.net/?variant=openjdk8) and [Maven 3+](https://maven.apache.org/download.cgi) (we have tested with Java SE 8, Java SE 11 and Java SE 17).
 
 ```
-mvn archetype:generate -DarchetypeGroupId="org.eclipse.starter" -DarchetypeArtifactId="jakarta-starter" -DarchetypeVersion="2.0-SNAPSHOT"
+mvn archetype:generate -DarchetypeGroupId="org.eclipse.starter" -DarchetypeArtifactId="jakarta-starter"
 ```
 
 If you use the defaults, this will generate the Jakarta EE project under a directory named `jakartaee-hello-world`. The README.md file 

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -16,7 +16,7 @@
 		<relativePath/>
 	</parent>
 
-	<name>Eclipse Starter for Jakarta EE</name>
+	<name>Eclipse Starter for Jakarta EE Archetypes</name>
 	<description>
 		This is the official Eclipse Foundation Starter for Jakarta EE.
 		It generates code to help get started with Jakarta EE projects. 

--- a/ui/README.md
+++ b/ui/README.md
@@ -12,7 +12,7 @@ mvn clean install
 ```
 
 ##  Running the UI
-In order to run the UI, please execute the following from this directory. You can also simply build the war from Maven and deploy the war to either WildFly 26 or JBoss EAP 7.4. You can do this in an IDE if desired. Note that you can override the underlying archetype version used by setting the `ARCHETYPE_VERSION` environment variable (the default version assumed is 2.0.0).
+In order to run the UI, please execute the following from this directory. You can also simply build the war from Maven and deploy the war to either WildFly 26 or JBoss EAP 7.4. You can do this in an IDE if desired. Note that you can override the underlying archetype version used by setting the `ARCHETYPE_VERSION` environment variable (the default version will be the most recent, see [here](https://github.com/eclipse-ee4j/starter/#readme) for the latest value).
 
 ```
 mvn clean package wildfly:run
@@ -29,7 +29,7 @@ Once the server is running, the source directories are monitored for changes. If
 Once WildFly starts, please go to http://localhost:8080/jakarta-starter-ui. Unzip the file the UI generates and follow the README.md in the unzipped directory.
 
 ##  Running the UI in DevMode
-In order to run the UI, please execute the following from this directory. You can also simply build the war from Maven and deploy the war to either WildFly 26 or JBoss EAP 7.4. You can do this in an IDE if desired. Note that you can override the underlying archetype version used by setting the `ARCHETYPE_VERSION` environment variable (the default version assumed is 2.0.0).
+In order to run the UI, please execute the following from this directory. You can also simply build the war from Maven and deploy the war to either WildFly 26 or JBoss EAP 7.4. You can do this in an IDE if desired. Note that you can override the underlying archetype version used by setting the `ARCHETYPE_VERSION` environment variable (the default version will be the most recent, see [here](https://github.com/eclipse-ee4j/starter/#readme) for the latest value).
 
 ```
 mvn clean package wildfly:run


### PR DESCRIPTION
I should have created this as a draft PR.    As I mentioned in [Slack](https://eclipsefoundationhq.slack.com/archives/C047MCS83FT/p1686254989851929)

> I noticed the m2 remote catalog file only has our v2.0.1 archetype  https://repo.maven.apache.org/maven2/archetype-catalog.xml (and has a 5/22 timestamp).
> Could we have messed something up?  Do we need to open a Sonatype issue or something?
> I never paid close attention to what the expected turnaround time would be but our 2.1.0 JAR has been in Mvn since 6/4.
