### PR TITLE
Add /api/version-info endpoint to UI, showing version info of UI itse…

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -80,6 +80,8 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.report.sourceEncoding>UTF-8</project.report.sourceEncoding>
+    <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+    <dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
   </properties>
 
   <dependencies>
@@ -125,6 +127,23 @@
 
   <build>
     <finalName>jakarta-starter-ui</finalName>
+      <resources>
+        <resource>
+        <directory>src/main/resources/</directory>
+         <filtering>true</filtering>
+         <includes>
+           <include>**/*.properties</include>
+         </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources/</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>**/*.properties</exclude>
+        </excludes>
+      </resource>
+    </resources>
+    
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -138,6 +157,19 @@
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- Execute 'mvn clean package wildfly:dev' to run the application. -->

--- a/ui/src/main/java/org/eclipse/starter/ui/Project.java
+++ b/ui/src/main/java/org/eclipse/starter/ui/Project.java
@@ -31,9 +31,6 @@ public class Project implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 	private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
-	private static final String ARCHETYPE_VERSION = (System.getenv("ARCHETYPE_VERSION") != null)
-			? System.getenv("ARCHETYPE_VERSION")
-			: "2.1.0";
 	private static final Map<String, String> RUNTIMES = Map.ofEntries(entry("glassfish", "GlassFish"),
 			entry("open-liberty", "Open Liberty"), entry("payara", "Payara"), entry("tomee", "TomEE"),
 			entry("wildfly", "WildFly"));
@@ -308,7 +305,7 @@ public class Project implements Serializable {
 						entry("profile", profile), entry("javaVersion", javaVersion),
 						entry("docker", (docker ? "yes" : "no")), entry("runtime", runtime)));
 
-				MavenUtility.invokeMavenArchetype("org.eclipse.starter", "jakarta-starter", ARCHETYPE_VERSION,
+				MavenUtility.invokeMavenArchetype("org.eclipse.starter", "jakarta-starter", VersionInfo.ARCHETYPE_VERSION,
 						properties, workingDirectory);
 
 				LOGGER.info("Creating zip file.");

--- a/ui/src/main/java/org/eclipse/starter/ui/RestApplication.java
+++ b/ui/src/main/java/org/eclipse/starter/ui/RestApplication.java
@@ -1,0 +1,9 @@
+package org.eclipse.starter.ui;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class RestApplication extends Application {
+
+}

--- a/ui/src/main/java/org/eclipse/starter/ui/VersionInfo.java
+++ b/ui/src/main/java/org/eclipse/starter/ui/VersionInfo.java
@@ -1,0 +1,48 @@
+package org.eclipse.starter.ui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/version-info")
+public class VersionInfo {
+
+	public static final String VERSION_PROPERTY = "version";
+	public static final String COMPILE_DEFAULT_ARCHETYPE_VERSION = "2.1.0";
+	public static final String ARCHETYPE_VERSION_ENV_VAR = System.getenv("ARCHETYPE_VERSION"); 
+	public static final String ARCHETYPE_VERSION = ( ARCHETYPE_VERSION_ENV_VAR != null)
+			? System.getenv("ARCHETYPE_VERSION")
+			: COMPILE_DEFAULT_ARCHETYPE_VERSION;
+	
+	Properties pomProperties = new Properties();
+	
+	public VersionInfo() throws IOException {
+		loadPomProperties();
+	}
+	
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public Response getProperties() {
+		Properties props = new Properties();
+		props.setProperty("FINAL ARCHETYPE VERSION", ARCHETYPE_VERSION);
+		props.setProperty("(compile-time default) archetype version", COMPILE_DEFAULT_ARCHETYPE_VERSION);
+		props.setProperty("UI VERSION", pomProperties.getProperty(VERSION_PROPERTY));
+        return Response.ok(props).build();
+	}
+	
+	private void loadPomProperties() throws IOException {
+    
+        InputStream is = this.getClass().getClassLoader()
+            .getResourceAsStream("version.properties");
+        pomProperties.load(is);
+    }
+
+    
+}
+

--- a/ui/src/main/resources/version.properties
+++ b/ui/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-${dev.build.timestamp}


### PR DESCRIPTION
…lf and archetypes

Implementing a basic version of the idea mentioned here:  https://www.eclipse.org/lists/starter-dev/msg00463.html

At URL:  `...../jakarta-starter-ui/api/version` we'd get data like:

```json
{
"UI VERSION":"2.0.2-20230619-2043",
"FINAL ARCHETYPE VERSION":"2.0.0",
"(compile-time default) archetype version":"2.1.0"
}
```