### PR TITLE
Use annotation based Jakarta REST config

### DIFF
--- a/archetype/src/main/resources/archetype-resources/src/main/java/jakarta/hello/HelloApplication.java
+++ b/archetype/src/main/resources/archetype-resources/src/main/java/jakarta/hello/HelloApplication.java
@@ -1,0 +1,9 @@
+package ${package}.jakarta.hello;
+
+import ${eePackage}.ws.rs.core.Application;
+import ${eePackage}.ws.rs.ApplicationPath;
+
+@ApplicationPath("rest")
+public class HelloApplication extends Application {
+    
+}

--- a/archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -15,13 +15,6 @@
 	xmlns="$xmlns"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="$schemaLocation">
-	<servlet>
-		<servlet-name>${eePackage}.ws.rs.core.Application</servlet-name>
-	</servlet>
-	<servlet-mapping>
-		<servlet-name>${eePackage}.ws.rs.core.Application</servlet-name>
-		<url-pattern>/rest/*</url-pattern>
-	</servlet-mapping>
 	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>
 	</welcome-file-list>


### PR DESCRIPTION
Ensure portable configuration via the jakarta.ws.rs.core.Application subclass

