### PR TITLE
Add groupId and artifactId to UI including validation (partly #274, #149, #150)

### DIFF
--- a/ui/src/main/java/org/eclipse/starter/ui/Project.java
+++ b/ui/src/main/java/org/eclipse/starter/ui/Project.java
@@ -35,6 +35,10 @@ public class Project implements Serializable {
 			entry("open-liberty", "Open Liberty"), entry("payara", "Payara"), entry("tomee", "TomEE"),
 			entry("wildfly", "WildFly"));
 
+	private static final String DEFAULT_GROUPID = "org.eclipse";;
+
+	private static final String DEFAULT_ARTIFACTID = "jakartaee-hello-world";
+
 	private static Map<String, String> cache = new ConcurrentHashMap<>();
 	
 	@Inject
@@ -57,6 +61,10 @@ public class Project implements Serializable {
 	private Map<String, SelectItem> runtimes = new LinkedHashMap<>();
 	private String runtime = "none";
 
+	private String groupId = DEFAULT_GROUPID;
+
+	private String artifactId = DEFAULT_ARTIFACTID;
+
 	public Project() {
 		jakartaVersions.put("10", new SelectItem("10", "Jakarta EE 10"));
 		jakartaVersions.put("9.1", new SelectItem("9.1", "Jakarta EE 9.1"));
@@ -64,7 +72,7 @@ public class Project implements Serializable {
 		jakartaVersions.put("8", new SelectItem("8", "Jakarta EE 8"));
 
 		profiles.put("full", new SelectItem("full", "Platform"));
-		profiles.put("web", new SelectItem("web", "Web Profile"));		
+		profiles.put("web", new SelectItem("web", "Web Profile"));
 		profiles.put("core", new SelectItem("core", "Core Profile"));
 
 		javaVersions.put("17", new SelectItem("17", "Java SE 17"));
@@ -142,6 +150,14 @@ public class Project implements Serializable {
 	public void setRuntime(String runtime) {
 		this.runtime = runtime;
 	}
+
+	public String getGroupId() { return groupId; }
+
+	public void setGroupId(String groupId) { this.groupId = groupId; }
+
+	public String getArtifactId() { return artifactId; }
+
+	public void setArtifactId(String artifactId) { this.artifactId = artifactId; }
 
 	public void onJakartaVersionChange() {
 		LOGGER.log(Level.INFO,
@@ -323,8 +339,8 @@ public class Project implements Serializable {
 	public void generate() {
 		try {
 			LOGGER.log(Level.INFO,
-					"Generating project - Jakarta EE version: {0}, Jakarta EE profile: {1}, Java SE version: {2}, Docker: {3}, runtime: {4}",
-					new Object[] { jakartaVersion, profile, javaVersion, docker, runtime });
+					"Generating project - Jakarta EE version: {0}, Jakarta EE profile: {1}, Java SE version: {2}, Docker: {3}, runtime: {4}, groupId: {5}, artifactId: {6}",
+					new Object[]{jakartaVersion, profile, javaVersion, docker, runtime, groupId, artifactId});
 
 			String cachedDirectory = cache.get(getCacheKey());
 
@@ -338,25 +354,34 @@ public class Project implements Serializable {
 						entry("jakartaVersion",
 								((jakartaVersion % 1.0 != 0) ? String.format("%s", jakartaVersion)
 										: String.format("%.0f", jakartaVersion))),
-						entry("profile", profile), entry("javaVersion", javaVersion),
-						entry("docker", (docker ? "yes" : "no")), entry("runtime", runtime)));
+						entry("profile", profile),
+						entry("javaVersion", javaVersion),
+						entry("docker", (docker ? "yes" : "no")),
+						entry("runtime", runtime),
+						entry("groupId", groupId),
+						entry("artifactId", artifactId),
+						entry("package", groupId)));
 
 				MavenUtility.invokeMavenArchetype("org.eclipse.starter", "jakarta-starter", VersionInfo.ARCHETYPE_VERSION,
 						properties, workingDirectory);
 
 				LOGGER.info("Creating zip file.");
-				ZipUtility.zipDirectory(new File(workingDirectory, "jakartaee-hello-world"), workingDirectory);
+				ZipUtility.zipDirectory(new File(workingDirectory, artifactId), workingDirectory);
 
 				LOGGER.info("Downloading zip file.");
-				downloadZip(new File(workingDirectory, "jakartaee-hello-world.zip"));
+				downloadZip(new File(workingDirectory, artifactId + ".zip"));
 
-				LOGGER.info("Caching output.");
-				cache.put(getCacheKey(), workingDirectory.getAbsolutePath());
+				// caching makes only sense if defaults weren't changed since otherwise it's unlikely to hit cache
+				if (groupId.equals(DEFAULT_GROUPID) && artifactId.equals(DEFAULT_ARTIFACTID)) {
+					LOGGER.info("Caching output.");
+					cache.put(getCacheKey(), workingDirectory.getAbsolutePath());
+				}
+
 				workingDirectory.deleteOnExit();
 			} else {
 				LOGGER.log(Level.INFO, "Downloading zip file from cached directory: {0}",
 						new Object[] { cachedDirectory });
-				downloadZip(new File(cachedDirectory, "jakartaee-hello-world.zip"));
+				downloadZip(new File(cachedDirectory, artifactId + ".zip"));
 			}
 
 			facesContext.responseComplete();
@@ -377,7 +402,7 @@ public class Project implements Serializable {
 			externalContext.setResponseContentType("application/zip");
 			externalContext.setResponseContentLength((int) zip.length());
 			externalContext.setResponseHeader("Content-Disposition",
-					"attachment; filename=\"jakartaee-hello-world.zip\"");
+					"attachment; filename=\"" + zip.getName() + "\"");
 
 			Files.copy(zip.toPath(), externalContext.getResponseOutputStream());
 		} catch (IOException e) {

--- a/ui/src/main/webapp/WEB-INF/template.xhtml
+++ b/ui/src/main/webapp/WEB-INF/template.xhtml
@@ -50,6 +50,16 @@
     .ui-panelgrid .ui-panelgrid-footer.ui-widget-header {
       text-align: center;
     }
+
+    .input-container {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .input-container .input-field {
+      flex-grow: 1;
+      margin-right: 10px;
+    }
   </h:outputStylesheet>
 
   <title>Eclipse Starter for Jakarta EE</title>

--- a/ui/src/main/webapp/index.xhtml
+++ b/ui/src/main/webapp/index.xhtml
@@ -23,15 +23,10 @@
       </p>
       <div class="card">
         <h:form>
+          <p:messages id="msg"/>
           <p:panelGrid
                   columnClasses="ui-grid-col-3, ui-grid-col-9"
                   columns="2" layout="grid" styleClass="text-align-left">
-
-            <p:row>
-              <p:column colspan="2">
-                <p:messages/>
-              </p:column>
-            </p:row>
 
             <p:outputLabel for="@next" value="Jakarta EE version" />
             <p:column>
@@ -85,12 +80,31 @@
               <h:outputText styleClass="footnote" value="Docker support requires a runtime other than GlassFish."/>
             </p:column>
 
+            <p:outputLabel for="@next" value="Group / Artifact"/>
+            <p:column>
+              <p:outputPanel class="input-container">
+                <p:inputText required="true" styleClass="input-field" value="#{project.groupId}"
+                             requiredMessage="Group has to be provided"
+                             validatorMessage="Group has to satisfy java package naming convention">
+                  <!-- groupId satisfies java package naming which must start with a letter followes by any number of letters, digits or underscore and then any number of similar parts separated by dot -->
+                  <f:validateRegex pattern="^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*$"/>
+                  <p:ajax event="change" update="@this,msg"/>
+                </p:inputText>
+                <p:inputText required="true" styleClass="input-field" value="#{project.artifactId}"
+                             requiredMessage="Artifact has to be provided"
+                             validatorMessage="Artifact has to satisfy jar naming convention">
+                  <!-- artifactId must start with a letter and then contain any number of letters, digits or underscore -->
+                  <f:validateRegex pattern="^[a-zA-Z][a-zA-Z0-9_-]*$"/>
+                  <p:ajax event="change" update="@this,msg"/>
+                </p:inputText>
+              </p:outputPanel>
+            </p:column>
+
             <f:facet name="footer">
               <p:commandButton value="Generate" ajax="false"
                                styleClass="generate-button"
                                icon="pi pi-arrow-down"
-                               action="#{project.generate}">
-              </p:commandButton>
+                               action="#{project.generate}"/>
             </f:facet>
 
           </p:panelGrid>


### PR DESCRIPTION
Enhance UI with two input fields for group and artifact id (layouted in 1 line to save space).
Both values are validated to java package naming convention and jar naming convention, respectively.
Validation messages appear for both empty and illegal field values on top of the form, both when pressing the button or when leaving the field. Button works directly from field as well as when having selected something else before.
Version was explicitely not regarded, as this can easily changed by the user and is seldomly useful to set at the beginning after creating a project template to anything else. Plus, the validation here would be different as the there are conventions, but the user could use something else as this has no effects on the generated files.
The archetype is fed with the new values or defaults are used if unchanged.
Only with the defaults caching happens as with individual values this would not make much sense as it is very unlikely to hit the cache if the values are freely set.
Was tested alone and in combination with the other PR using the artifactId in all files.
