### PR TITLE
Fixed README.md files - added Markdown Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In order to run the UI, please execute the following from this directory. You ca
 mvn clean package wildfly:dev --file ui/pom.xml
 ```
 
-Once WildFly starts, please go to http://localhost:8080/jakarta-starter-ui/. Unzip the file the UI generates and follow the README.md in the unzipped directory.
+Once WildFly starts, please go to [http://localhost:8080/jakarta-starter-ui/](http://localhost:8080/jakarta-starter-ui/). Unzip the file the UI generates and follow the README.md in the unzipped directory.
 
 ## Known Issues
 * Note that Payara does not yet work on the Apple M1 chip. If you are on an M1 chip, we suggest you use another runtime for the time being with the Archetype.

--- a/archetype/src/main/resources/archetype-resources/README.md
+++ b/archetype/src/main/resources/archetype-resources/README.md
@@ -20,11 +20,11 @@ You can run the application by executing the following command from the director
 ```
 
 #if ((${runtime} == 'payara') && (${profile} != 'full'))
-Once the runtime starts, you can access the project at http://localhost:8080.
+Once the runtime starts, you can access the project at http://localhost:8080
 #elseif (${runtime} == 'open-liberty')
-Once the runtime starts, you can access the project at http://localhost:9080.
+Once the runtime starts, you can access the project at http://localhost:9080
 #else
-Once the runtime starts, you can access the project at http://localhost:8080/jakartaee-hello-world.
+Once the runtime starts, you can access the project at http://localhost:8080/jakartaee-hello-world
 #end
 
 #if ((${docker} == 'yes') and (${runtime} != 'glassfish'))
@@ -46,9 +46,9 @@ docker run -it --rm -p 9080:9080 jakartaee-hello-world:v1
 ```
 
 #if (${runtime} != 'open-liberty')
-Once the runtime starts, you can access the project at http://localhost:8080/jakartaee-hello-world.
+Once the runtime starts, you can access the project at http://localhost:8080/jakartaee-hello-world
 #else
-Once the runtime starts, you can access the project at http://localhost:9080/.
+Once the runtime starts, you can access the project at http://localhost:9080/
 #end
 #end
 #else

--- a/ui/README.md
+++ b/ui/README.md
@@ -18,4 +18,4 @@ In order to run the UI, please execute the following from this directory. You ca
 mvn clean package wildfly:dev
 ```
 
-Once WildFly starts, please go to http://localhost:8080/jakarta-starter-ui. Unzip the file the UI generates and follow the README.md in the unzipped directory.
+Once WildFly starts, please go to http://localhost:8080/jakarta-starter-ui Unzip the file the UI generates and follow the README.md in the unzipped directory.

--- a/ui/README.md
+++ b/ui/README.md
@@ -18,4 +18,4 @@ In order to run the UI, please execute the following from this directory. You ca
 mvn clean package wildfly:dev
 ```
 
-Once WildFly starts, please go to http://localhost:8080/jakarta-starter-ui Unzip the file the UI generates and follow the README.md in the unzipped directory.
+Once WildFly starts, please go to [http://localhost:8080/jakarta-starter-ui](http://localhost:8080/jakarta-starter-ui). Unzip the file the UI generates and follow the README.md in the unzipped directory.


### PR DESCRIPTION
I removed the '.' character from the README.md files as this can cause a copy/paste problem if users are not aware that the '.' is not part of the URL. I added markdown links. 