### PR TITLE
Add all negative cases for Open Liberty

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,6 +90,32 @@ jobs:
           docker rmi test-image
           rm -rf app/open-liberty
 
+      - name: Run Archetype for EE 8 Core Profile, SE 8, Open Liberty
+        id: ee_8_core_se_8_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_8_core_se_8_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 8 Core Profile, SE 8, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 8 Core Profile, SE 8, Open Liberty, with Docker
+        id: ee_8_core_se_8_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_8_core_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 8 Core Profile, SE 8, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
       - name: Run Archetype for EE 9, SE 8, Open Liberty
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=full -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -114,6 +140,32 @@ jobs:
           docker rmi test-image
           rm -rf app/open-liberty
 
+      - name: Run Archetype for EE 9 Core Profile, SE 8, Open Liberty
+        id: ee_9_core_se_8_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9_core_se_8_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9 Core Profile, SE 8, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 9 Core Profile, SE 8, Open Liberty, with Docker
+        id: ee_9_core_se_8_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9_core_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9 Core Profile, SE 8, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
       - name: Run Archetype for EE 9.1, SE 8, Open Liberty
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=full -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -137,6 +189,110 @@ jobs:
           docker build -t test-image app/open-liberty/jakartaee-hello-world
           docker rmi test-image
           rm -rf app/open-liberty
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 8, Open Liberty
+        id: ee_9.1_core_se_8_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9.1_core_se_8_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9.1 Core Profile, SE 8, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 8, Open Liberty, with Docker
+        id: ee_9.1_core_se_8_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9.1_core_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9.1 Core Profile, SE 8, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 10, SE 8, Open Liberty
+        id: ee_10_se_8_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=full -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_10_se_8_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 10, SE 8, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 10, SE 8, Open Liberty, with Docker
+        id: ee_10_se_8_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=full -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_10_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 10, SE 8, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 10 Web Profile, SE 8, Open Liberty
+        id: ee_10_web_se_8_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=web -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_10_web_se_8_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 10 Web Profile, SE 8, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 10 Web Profile, SE 8, Open Liberty, with Docker
+        id: ee_10_web_se_8_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=web -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_10_web_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 10 Web Profile, SE 8, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 10 Core Profile, SE 8, Open Liberty
+        id: ee_10_core_se_8_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_10_core_se_8_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 10 Core Profile, SE 8, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 10 Core Profile, SE 8, Open Liberty, with Docker
+        id: ee_10_core_se_8_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_10_core_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 10 Core Profile, SE 8, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
 
       - name: Run Archetype for EE 8 Web Profile, SE 8, TomEE
         run: |
@@ -242,6 +398,32 @@ jobs:
           docker rmi test-image
           rm -rf app/open-liberty
 
+      - name: Run Archetype for EE 8 Core Profile, SE 11, Open Liberty
+        id: ee_8_core_se_11_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_8_core_se_11_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 8 Core Profile, SE 11, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 8 Core Profile, SE 11, Open Liberty, with Docker
+        id: ee_8_core_se_11_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_8_core_se_11_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 8 Core Profile, SE 11, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
       - name: Run Archetype for EE 9, SE 11, Open Liberty
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=full -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -266,6 +448,32 @@ jobs:
           docker rmi test-image
           rm -rf app/open-liberty
 
+      - name: Run Archetype for EE 9 Core Profile, SE 11, Open Liberty
+        id: ee_9_core_se_11_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9_core_se_11_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9 Core Profile, SE 11, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 9 Core Profile, SE 11, Open Liberty, with Docker
+        id: ee_9_core_se_11_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9_core_se_11_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9 Core Profile, SE 11, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
       - name: Run Archetype for EE 9.1, SE 11, Open Liberty
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=full -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -289,6 +497,32 @@ jobs:
           docker build -t test-image app/open-liberty/jakartaee-hello-world
           docker rmi test-image
           rm -rf app/open-liberty
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 11, Open Liberty
+        id: ee_9.1_core_se_11_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9.1_core_se_11_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9.1 Core Profile, SE 11, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 11, Open Liberty, with Docker
+        id: ee_9.1_core_se_11_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9.1_core_se_11_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9.1 Core Profile, SE 11, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
 
       - name: Run Archetype for EE 10, SE 11, Open Liberty
         run: |
@@ -476,6 +710,32 @@ jobs:
           docker rmi test-image
           rm -rf app/open-liberty
 
+      - name: Run Archetype for EE 8 Core Profile, SE 17, Open Liberty
+        id: ee_8_core_se_17_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_8_core_se_17_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 8 Core Profile, SE 17, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 8 Core Profile, SE 17, Open Liberty, with Docker
+        id: ee_8_core_se_17_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_8_core_se_17_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 8 Core Profile, SE 17, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
       - name: Run Archetype for EE 9, SE 17, Open Liberty
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=full -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -500,6 +760,32 @@ jobs:
           docker rmi test-image
           rm -rf app/open-liberty
 
+      - name: Run Archetype for EE 9 Core Profile, SE 17, Open Liberty
+        id: ee_9_core_se_17_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9_core_se_17_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9 Core Profile, SE 17, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 9 Core Profile, SE 17, Open Liberty, with Docker
+        id: ee_9_core_se_17_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9_core_se_17_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9 Core Profile, SE 17, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
+
       - name: Run Archetype for EE 9.1, SE 17, Open Liberty
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=full -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -523,6 +809,32 @@ jobs:
           docker build -t test-image app/open-liberty/jakartaee-hello-world
           docker rmi test-image
           rm -rf app/open-liberty
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 17, Open Liberty
+        id: ee_9.1_core_se_17_openliberty
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9.1_core_se_17_openliberty'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9.1 Core Profile, SE 17, Open Liberty succeeded, test failed."
+            exit 1
+          fi
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 17, Open Liberty, with Docker
+        id: ee_9.1_core_se_17_openliberty_docker
+        continue-on-error: true
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
+
+      - name: Check Maven Build Status
+        run: |
+          if [[ "${{ steps['ee_9.1_core_se_17_openliberty_docker'].outcome }}" != "failure" ]]; then
+            echo "Maven build for EE 9.1 Core Profile, SE 17, Open Liberty, with Docker succeeded, test failed."
+            exit 1
+          fi
 
       - name: Run Archetype for EE 10, SE 17, Open Liberty
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Check Maven Build Status
         run: |
-          if [[ "${{ steps['ee_9.1_core_se_8_openliberty'].outcome }}" != "failure" ]]; then
+          if [[ "${{ steps['ee_9-1_core_se_8_openliberty'].outcome }}" != "failure" ]]; then
             echo "Maven build for EE 9.1 Core Profile, SE 8, Open Liberty succeeded, test failed."
             exit 1
           fi
@@ -211,7 +211,7 @@ jobs:
 
       - name: Check Maven Build Status
         run: |
-          if [[ "${{ steps['ee_9.1_core_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
+          if [[ "${{ steps['ee_9-1_core_se_8_openliberty_docker'].outcome }}" != "failure" ]]; then
             echo "Maven build for EE 9.1 Core Profile, SE 8, Open Liberty, with Docker succeeded, test failed."
             exit 1
           fi
@@ -506,7 +506,7 @@ jobs:
 
       - name: Check Maven Build Status
         run: |
-          if [[ "${{ steps['ee_9.1_core_se_11_openliberty'].outcome }}" != "failure" ]]; then
+          if [[ "${{ steps['ee_9-1_core_se_11_openliberty'].outcome }}" != "failure" ]]; then
             echo "Maven build for EE 9.1 Core Profile, SE 11, Open Liberty succeeded, test failed."
             exit 1
           fi
@@ -519,7 +519,7 @@ jobs:
 
       - name: Check Maven Build Status
         run: |
-          if [[ "${{ steps['ee_9.1_core_se_11_openliberty_docker'].outcome }}" != "failure" ]]; then
+          if [[ "${{ steps['ee_9-1_core_se_11_openliberty_docker'].outcome }}" != "failure" ]]; then
             echo "Maven build for EE 9.1 Core Profile, SE 11, Open Liberty, with Docker succeeded, test failed."
             exit 1
           fi
@@ -818,7 +818,7 @@ jobs:
 
       - name: Check Maven Build Status
         run: |
-          if [[ "${{ steps['ee_9.1_core_se_17_openliberty'].outcome }}" != "failure" ]]; then
+          if [[ "${{ steps['ee_9-1_core_se_17_openliberty'].outcome }}" != "failure" ]]; then
             echo "Maven build for EE 9.1 Core Profile, SE 17, Open Liberty succeeded, test failed."
             exit 1
           fi
@@ -831,7 +831,7 @@ jobs:
 
       - name: Check Maven Build Status
         run: |
-          if [[ "${{ steps['ee_9.1_core_se_17_openliberty_docker'].outcome }}" != "failure" ]]; then
+          if [[ "${{ steps['ee_9-1_core_se_17_openliberty_docker'].outcome }}" != "failure" ]]; then
             echo "Maven build for EE 9.1 Core Profile, SE 17, Open Liberty, with Docker succeeded, test failed."
             exit 1
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -191,7 +191,7 @@ jobs:
           rm -rf app/open-liberty
 
       - name: Run Archetype for EE 9.1 Core Profile, SE 8, Open Liberty
-        id: ee_9.1_core_se_8_openliberty
+        id: ee_9-1_core_se_8_openliberty
         continue-on-error: true
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -204,7 +204,7 @@ jobs:
           fi
 
       - name: Run Archetype for EE 9.1 Core Profile, SE 8, Open Liberty, with Docker
-        id: ee_9.1_core_se_8_openliberty_docker
+        id: ee_9-1_core_se_8_openliberty_docker
         continue-on-error: true
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -499,7 +499,7 @@ jobs:
           rm -rf app/open-liberty
 
       - name: Run Archetype for EE 9.1 Core Profile, SE 11, Open Liberty
-        id: ee_9.1_core_se_11_openliberty
+        id: ee_9-1_core_se_11_openliberty
         continue-on-error: true
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -512,7 +512,7 @@ jobs:
           fi
 
       - name: Run Archetype for EE 9.1 Core Profile, SE 11, Open Liberty, with Docker
-        id: ee_9.1_core_se_11_openliberty_docker
+        id: ee_9-1_core_se_11_openliberty_docker
         continue-on-error: true
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -811,7 +811,7 @@ jobs:
           rm -rf app/open-liberty
 
       - name: Run Archetype for EE 9.1 Core Profile, SE 17, Open Liberty
-        id: ee_9.1_core_se_17_openliberty
+        id: ee_9-1_core_se_17_openliberty
         continue-on-error: true
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=no -DoutputDirectory="app/open-liberty" -Dgoals="clean package"
@@ -824,7 +824,7 @@ jobs:
           fi
 
       - name: Run Archetype for EE 9.1 Core Profile, SE 17, Open Liberty, with Docker
-        id: ee_9.1_core_se_17_openliberty_docker
+        id: ee_9-1_core_se_17_openliberty_docker
         continue-on-error: true
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime="open-liberty" -Ddocker=yes -DoutputDirectory="app/open-liberty" -Dgoals="clean package"


### PR DESCRIPTION
This completes all validation cases for Open Liberty by adding all negative cases. All the negative cases for Open Liberty are ones where the build should fail. And they are of two types:

1. Cases failing due to having EE 10 with SE 8
2. Cases failing due to having the core profile with an EE version that's not 10