### PR TITLE
Add negative cases for Payara

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -267,87 +267,9 @@ jobs:
 
           rm -f mvn_output.txt
 
-      - name: Run Archetype for EE 9, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9 Web Profile, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=web -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9 Web Profile, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=web -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
       - name: Run Archetype for EE 9.1, SE 8, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9.1, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9.1 Web Profile, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=web -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9.1 Web Profile, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=web -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
 
           MAVEN_EXIT_CODE=${PIPESTATUS[0]}
           ERROR_MESSAGE="Payara 6 does not support Java SE 8"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -254,6 +254,266 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
+      - name: Run Archetype for EE 8 Core Profile, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 8 Core Profile, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9 Web Profile, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=web -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9 Web Profile, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=web -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9 Core Profile, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9 Core Profile, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1 Web Profile, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=web -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1 Web Profile, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=web -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Payara 6 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 10, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 10, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 10 Web Profile, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=web -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 10 Web Profile, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=web -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 10 Core Profile, SE 8, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 10 Core Profile, SE 8, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
       - name: Run Archetype for EE 8 Web Profile, SE 8, TomEE
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=web -DjavaVersion=8 -Druntime=tomee -DoutputDirectory=app/tomee -Dgoals="clean package"
@@ -563,6 +823,32 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
+      - name: Run Archetype for EE 8 Core Profile, SE 11, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 8 Core Profile, SE 11, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=11 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
       - name: Run Archetype for EE 9, SE 11, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -587,6 +873,32 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
+      - name: Run Archetype for EE 9 Core Profile, SE 11, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9 Core Profile, SE 11, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=11 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
       - name: Run Archetype for EE 9.1, SE 11, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -610,6 +922,32 @@ jobs:
           docker build -t test-image app/payara/jakartaee-hello-world
           docker rmi test-image
           rm -rf app/payara
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 11, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 11, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
 
       - name: Run Archetype for EE 10, SE 11, Payara
         run: |
@@ -967,6 +1305,32 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
+      - name: Run Archetype for EE 8 Core Profile, SE 17, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 8 Core Profile, SE 17, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=17 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
       - name: Run Archetype for EE 9, SE 17, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -991,6 +1355,32 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
+      - name: Run Archetype for EE 9 Core Profile, SE 17, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9 Core Profile, SE 17, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=17 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
       - name: Run Archetype for EE 9.1, SE 17, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -1014,6 +1404,32 @@ jobs:
           docker build -t test-image app/payara/jakartaee-hello-world
           docker rmi test-image
           rm -rf app/payara
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 17, Payara
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
+
+      - name: Run Archetype for EE 9.1 Core Profile, SE 17, Payara, with Docker
+        run: |
+          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
+
+          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
+          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
+          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
+              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
+              exit 1
+          fi
+
+          rm -f mvn_output.txt
 
       - name: Run Archetype for EE 10, SE 17, Payara
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -254,32 +254,6 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
-      - name: Run Archetype for EE 8 Core Profile, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 8 Core Profile, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
       - name: Run Archetype for EE 9, SE 8, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
@@ -332,32 +306,6 @@ jobs:
 
           rm -f mvn_output.txt
 
-      - name: Run Archetype for EE 9 Core Profile, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9 Core Profile, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
       - name: Run Archetype for EE 9.1, SE 8, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
@@ -403,110 +351,6 @@ jobs:
 
           MAVEN_EXIT_CODE=${PIPESTATUS[0]}
           ERROR_MESSAGE="Payara 6 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9.1 Core Profile, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9.1 Core Profile, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 10, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 10, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 10 Web Profile, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=web -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 10 Web Profile, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=web -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 10 Core Profile, SE 8, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=core -DjavaVersion=8 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 10 Core Profile, SE 8, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=10 -Dprofile=core -DjavaVersion=8 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="Jakarta EE 10 does not support Java SE 8"
           if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
               echo "Maven build did not fail, or the expected error message was not found. Test Failed."
               exit 1
@@ -823,32 +667,6 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
-      - name: Run Archetype for EE 8 Core Profile, SE 11, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 8 Core Profile, SE 11, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=11 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
       - name: Run Archetype for EE 9, SE 11, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -873,32 +691,6 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
-      - name: Run Archetype for EE 9 Core Profile, SE 11, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9 Core Profile, SE 11, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=11 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
       - name: Run Archetype for EE 9.1, SE 11, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -922,32 +714,6 @@ jobs:
           docker build -t test-image app/payara/jakartaee-hello-world
           docker rmi test-image
           rm -rf app/payara
-
-      - name: Run Archetype for EE 9.1 Core Profile, SE 11, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9.1 Core Profile, SE 11, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=11 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
 
       - name: Run Archetype for EE 10, SE 11, Payara
         run: |
@@ -1305,32 +1071,6 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
-      - name: Run Archetype for EE 8 Core Profile, SE 17, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 8 Core Profile, SE 17, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=8 -Dprofile=core -DjavaVersion=17 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
       - name: Run Archetype for EE 9, SE 17, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -1355,32 +1095,6 @@ jobs:
           docker rmi test-image
           rm -rf app/payara
 
-      - name: Run Archetype for EE 9 Core Profile, SE 17, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9 Core Profile, SE 17, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9 -Dprofile=core -DjavaVersion=17 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
       - name: Run Archetype for EE 9.1, SE 17, Payara
         run: |
           mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package"
@@ -1404,32 +1118,6 @@ jobs:
           docker build -t test-image app/payara/jakartaee-hello-world
           docker rmi test-image
           rm -rf app/payara
-
-      - name: Run Archetype for EE 9.1 Core Profile, SE 17, Payara
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime=payara -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
-
-      - name: Run Archetype for EE 9.1 Core Profile, SE 17, Payara, with Docker
-        run: |
-          mvn archetype:generate -DinteractiveMode=false -DaskForDefaultPropertyValues=false -DarchetypeGroupId=org.eclipse.starter -DarchetypeArtifactId=jakarta-starter -DarchetypeVersion=2.3.0-SNAPSHOT -DjakartaVersion=9.1 -Dprofile=core -DjavaVersion=17 -Druntime=payara -Ddocker=yes -DoutputDirectory=app/payara -Dgoals="clean package" | tee mvn_output.txt
-
-          MAVEN_EXIT_CODE=${PIPESTATUS[0]}
-          ERROR_MESSAGE="the Core Profile is only supported for Jakarta EE 10"
-          if ! { [ $MAVEN_EXIT_CODE -ne 0 ] && grep -q "$ERROR_MESSAGE" mvn_output.txt; }; then
-              echo "Maven build did not fail, or the expected error message was not found. Test Failed."
-              exit 1
-          fi
-
-          rm -f mvn_output.txt
 
       - name: Run Archetype for EE 10, SE 17, Payara
         run: |


### PR DESCRIPTION
This adds two negative cases to cover the case "Payara 6 does not support Java SE 8" from [https://github.com/eclipse-ee4j/starter/blob/master/archetype/src/main/resources/META-INF/archetype-post-generate.groovy](https://github.com/eclipse-ee4j/starter/blob/master/archetype/src/main/resources/META-INF/archetype-post-generate.groovy). The two added cases are for EE 9 and EE 9.1. No case added for EE 10 since it's covered under EE 10 not supporting SE 8.