### PR TITLE
Fix broken breadcrumbs link in Eclipse Starter for Jakarta EE

### DIFF
--- a/ui/src/main/webapp/WEB-INF/topbar.xhtml
+++ b/ui/src/main/webapp/WEB-INF/topbar.xhtml
@@ -180,7 +180,7 @@
               <a href="https://jakarta.ee/">Home</a>
             </li>
             <li class="active">
-              <a href="https://eclipse-ee4j.github.io/starter/">Eclipse Starter for Jakarta EE</a>
+              <a href="https://start.jakarta.ee/">Eclipse Starter for Jakarta EE</a>
             </li>
           </ol>
         </div>

--- a/ui/src/main/webapp/WEB-INF/topbar.xhtml
+++ b/ui/src/main/webapp/WEB-INF/topbar.xhtml
@@ -146,7 +146,7 @@
               </button>
               <div class="wrapper-logo-mobile">
                 <a class="navbar-brand visible-xs"
-                   href="https://eclipse-ee4j.github.io/starter/"
+                   href="https://start.jakarta.ee/"
                    title="Jakarta EE: The New Home of Cloud Native Java">
                   <img alt="Jakarta EE: The New Home of Cloud Native Java" class="logo-eclipse-default-mobile img-responsive"
                        src="https://jakarta.ee/images/jakarta/jakarta-ee-logo.svg"


### PR DESCRIPTION
Updated the breadcrumbs link to point to the correct site: https://start.jakarta.ee, replacing the outdated URL.