### PR TITLE
Use IBM UBI images instead of Docker Hub images

### DIFF
--- a/archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/archetype/src/main/resources/archetype-resources/Dockerfile
@@ -95,8 +95,10 @@
 #set ($baseImage = "icr.io/appcafe/open-liberty:full-java17-openj9-ubi")
 #elseif (${javaVersion} == '11')
 #set ($baseImage = "icr.io/appcafe/open-liberty:full-java11-openj9-ubi")
-#else
+#elseif (${javaVersion} == '8')
 #set ($baseImage = "icr.io/appcafe/open-liberty:full-java8-openj9-ubi")
+#else
+#set ($baseImage = "icr.io/appcafe/open-liberty:latest")
 #end
 #set ($deployDirectory = "/config/apps/")
 #end

--- a/archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/archetype/src/main/resources/archetype-resources/Dockerfile
@@ -92,13 +92,11 @@
 #elseif (${javaVersion} == '21')
 #set ($baseImage = "icr.io/appcafe/open-liberty:full-java21-openj9-ubi-minimal")
 #elseif (${javaVersion} == '17')
-#set ($baseImage = "open-liberty:full-java17-openj9")
+#set ($baseImage = "icr.io/appcafe/open-liberty:full-java17-openj9-ubi")
 #elseif (${javaVersion} == '11')
-#set ($baseImage = "open-liberty:full-java11-openj9")
-#elseif (${javaVersion} == '8')
-#set ($baseImage = "open-liberty:full-java8-openj9")
+#set ($baseImage = "icr.io/appcafe/open-liberty:full-java11-openj9-ubi")
 #else
-#set ($baseImage = "open-liberty:full")
+#set ($baseImage = "icr.io/appcafe/open-liberty:full-java8-openj9-ubi")
 #end
 #set ($deployDirectory = "/config/apps/")
 #end

--- a/archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/archetype/src/main/resources/archetype-resources/Dockerfile
@@ -89,6 +89,8 @@
 ## Once Open Liberty has a proper release for EE 11, this should be removed.
 #if (${jakartaVersion} == '11')
 #set ($baseImage = "icr.io/appcafe/open-liberty:beta")
+#elseif (${javaVersion} == '21')
+#set ($baseImage = "icr.io/appcafe/open-liberty:full-java21-openj9-ubi-minimal")
 #elseif (${javaVersion} == '17')
 #set ($baseImage = "open-liberty:full-java17-openj9")
 #elseif (${javaVersion} == '11')


### PR DESCRIPTION
Also switch Open Liberty images to icr.io for Java < 21. As it seems to be the recommended way: https://github.com/OpenLiberty/ci.docker/blob/main/docs/icr-images.md