### PR TITLE
Add Velocity indentation plugin to plugins (to the velocity-indentation-experiment branch)

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -97,6 +97,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- Remove leading spaces from Velocity code. -->
+                        <id>remove-leading-spaces</id>
+                        <phase>process-resources</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -130,13 +140,12 @@
                         <execution>
                             <!-- Remove leading spaces from Velocity code. -->
                             <id>remove-leading-spaces</id>
-                            <phase>process-resources</phase>
                             <goals>
                                 <goal>run</goal>
                             </goals>
                             <configuration>
                                 <target>
-                                    <replaceregexp match="^\s*(#(if|else|set|elseif|end))"
+                                    <replaceregexp match="^\s*(#(#|if|else|set|elseif|end))"
                                                    replace="\1"
                                                    flags="g" 
                                                    byline="true">


### PR DESCRIPTION
The plugin was defined only in `pluginManagement` and not in `plugins`, so it wasn't automatically executed. 
Also added support for un-indenting Velocity comments (lines that start with space followed by `##`)