### PR TITLE
switch to client state saving to avoid ViewExpiredException

### DIFF
--- a/ui/src/main/webapp/WEB-INF/web.xml
+++ b/ui/src/main/webapp/WEB-INF/web.xml
@@ -3,6 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
     <context-param>
+        <param-name>jakarta.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>client</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>
+        <param-value>65535</param-value>
+    </context-param>
+    <context-param>
         <param-name>primefaces.THEME</param-name>
         <param-value>saga</param-value>
     </context-param>


### PR DESCRIPTION
also bumped Facelets buffer size because the landing page referenced the view scoped bean for the first time after the response is committed