### PR TITLE
Fix classpath and logging issues

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -89,6 +89,24 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
             <version>3.9.12</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-slf4j-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Dependencies for Embedded Maven -->
@@ -243,7 +261,7 @@
                         </resources>
                     </deployment>
                 </configuration>
-            </plugin>            
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -148,11 +148,6 @@
             <version>1.29</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-            <version>2.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>5.1.0</version>
@@ -161,7 +156,7 @@
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-servlet</artifactId>
             <version>5.1.0</version>
-        </dependency>        
+        </dependency>
     </dependencies>
 
     <build>
@@ -176,6 +171,44 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.5.1</version>
+            </plugin>
+
+            <!-- Check for duplicate classes in the WAR file -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-ban-duplicate-classes</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <banDuplicateClasses>
+                                    <scopes>
+                                        <scope>compile</scope>
+                                        <scope>runtime</scope>
+                                    </scopes>
+                                    <findAllDuplicates>true</findAllDuplicates>
+                                    <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                    <ignoreClasses>
+                                        <ignoreClass>com.google.inject.*</ignoreClass>
+                                    </ignoreClasses>
+                                </banDuplicateClasses>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.8.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <!-- Execute 'mvn clean package wildfly:dev' to run the application. -->
@@ -210,7 +243,7 @@
                         </resources>
                     </deployment>
                 </configuration>
-            </plugin>
+            </plugin>            
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
* Fix an issue where two copies of classes in the `org.codehaus.plexus` package are added into the same JAR, one from the direct dependency on `org.codehaus.plexus:plexus-container-default:2.1.1` and another bundled inside `org.eclipse.sisu.plexus-0.9.0.M4.jar` which is a transitive dependency of `org.apache.maven:maven-embedder:3.9.12`. This causes exceptions at runtime when the wrong copy of the class is loaded.

* Add the `maven-enforcer-plugin` with configuration to avoid the issue above from happening by using the `enforce-ban-duplicate-classes` rule which prevents multiple copies of a class inside an artifact.

* Add exclusions to the loggers that can be used by `maven-embedder`, to avoid warnings about multiple loggers that can conflict with JBoss' own logging infrastructure:

```
2026-07-13 00:23:42,671 WARN  [org.apache.maven.cli.logging.impl.UnsupportedSlf4jBindingConfiguration] (default task-3) The SLF4J binding actually used is not supported by Maven: org.slf4j.impl.Slf4jLoggerFactory
2026-07-13 00:23:42,672 WARN  [org.apache.maven.cli.logging.impl.UnsupportedSlf4jBindingConfiguration] (default task-3) Maven supported bindings are:
2026-07-13 00:23:42,673 WARN  [org.apache.maven.cli.logging.impl.UnsupportedSlf4jBindingConfiguration] (default task-3) (from vfs:/content/ROOT.war/WEB-INF/lib/maven-embedder-3.9.12.jar/META-INF/maven/slf4j-configuration.properties)
- org.slf4j.impl.SimpleLoggerFactory
- org.slf4j.impl.MavenSimpleLoggerFactory
- ch.qos.logback.classic.LoggerContext
- org.apache.logging.slf4j.Log4jLoggerFactory
```